### PR TITLE
Hold mode observer

### DIFF
--- a/PMMain/Midas/MidasGUI/BaseMeasurements.h
+++ b/PMMain/Midas/MidasGUI/BaseMeasurements.h
@@ -55,21 +55,33 @@ public:
 
 	void setControlStateHandle(ControlState* controlState) { controlStateHandle = controlState; }
 
-	float getBaseRoll() { return baseRoll; }
-	float getBasePitch() { return basePitch; }
-	float getBaseYaw() { return baseYaw; }
-	float getBaseCursorX() { return baseCursorX; }
-	float getBaseCursorY() { return baseCursorY; }
-	float getScreenSizeX() { return screenSizeX; }
-	float getScreenSizeY() { return screenSizeY; }
-	myo::Pose BaseMeasurements::getCurrentPose() { return currentPose; }
-	midasMode BaseMeasurements::getCurrentState() { return currentState; }
+    float getCurrentRoll()    { accessMutex.lock();   float retVal = currentRoll;     accessMutex.unlock(); return retVal; }
+    float getCurrentPitch()   { accessMutex.lock();   float retVal = currentPitch;    accessMutex.unlock(); return retVal; }
+    float getCurrentYaw()     { accessMutex.lock();   float retVal = currentYaw;      accessMutex.unlock(); return retVal; }
+	float getBaseRoll()    { accessMutex.lock();   float retVal = baseRoll;     accessMutex.unlock(); return retVal; }
+	float getBasePitch()   { accessMutex.lock();   float retVal = basePitch;    accessMutex.unlock(); return retVal; }
+	float getBaseYaw()     { accessMutex.lock();   float retVal = baseYaw;      accessMutex.unlock(); return retVal; }
+	float getBaseCursorX() { accessMutex.lock();   float retVal = baseCursorX;  accessMutex.unlock(); return retVal; }
+	float getBaseCursorY() { accessMutex.lock();   float retVal = baseCursorY;  accessMutex.unlock(); return retVal; }
+	float getScreenSizeX() { accessMutex.lock();   float retVal = screenSizeX;  accessMutex.unlock(); return retVal; }
+	float getScreenSizeY() { accessMutex.lock();   float retVal = screenSizeY;  accessMutex.unlock(); return retVal; }
+    myo::Pose BaseMeasurements::getCurrentPose() { accessMutex.lock(); myo::Pose retVal = currentPose;  accessMutex.unlock(); return retVal; }
+    midasMode BaseMeasurements::getCurrentState() { accessMutex.lock(); midasMode retVal = currentState; accessMutex.unlock(); return retVal; }
 
 	bool areCurrentValuesValid();
 
 private:
 	// Force as singleton
-	BaseMeasurements() { myoStateHandle = NULL; currentState = LOCK_MODE; currentPose = myo::Pose::rest; };
+	BaseMeasurements() { 
+        baseRoll = 0; basePitch = 0; baseYaw = 0;
+        baseCursorX = 0; baseCursorY = 0; 
+        screenSizeX = 0; screenSizeY = 0;
+        currentRoll = 0; currentPitch = 0; currentYaw = 0;
+        myoStateHandle = NULL;
+        controlStateHandle = NULL;
+        currentState = LOCK_MODE;
+        currentPose = myo::Pose::rest; 
+    };
 	//~BaseMeasurements();
 	BaseMeasurements(BaseMeasurements const&) = delete;
 	void operator=(BaseMeasurements const&) = delete;

--- a/PMMain/Midas/MidasGUI/Filter.cpp
+++ b/PMMain/Midas/MidasGUI/Filter.cpp
@@ -28,52 +28,76 @@ void Filter::addDataAsInput(std::string name, boost::any value)
 
 void Filter::setInput(filterDataMap input)
 {
+    filterMutex.lock();
     inputData = input;
+    filterMutex.unlock();
 }
 
 filterDataMap Filter::getOutput()
 {
-    return outputData;
+    filterMutex.lock();
+    filterDataMap retVal = outputData;
+    filterMutex.unlock();
+    return retVal;
 }
 
 filterStatus Filter::getFilterStatus()
 {
-    return status;
+    filterMutex.lock();
+    filterStatus retVal = status;
+    filterMutex.unlock();
+    return retVal;
 }
 
 filterError Filter::getFilterError()
 {
-    return error;
+    filterMutex.lock();
+    filterError retVal = error;
+    filterMutex.unlock();
+    return retVal;
 }
 
 void Filter::setFilterStatus(filterStatus status)
 {
+    filterMutex.lock();
     this->status = status;
+    filterMutex.unlock();
 }
 
 void Filter::setFilterError(filterError error)
 {
+    filterMutex.lock();
     this->error = error;
+    filterMutex.unlock();
 }
 
 filterDataMap Filter::getInput()
 {
-    return inputData;
+    filterMutex.lock();
+    filterDataMap retVal = inputData;
+    filterMutex.unlock();
+    return retVal;
 }
 
 void Filter::setOutput(filterDataMap output)
 {
+    filterMutex.lock();
     outputData = output;
+    filterMutex.unlock();
 }
 
 void Filter::addToOutput(filterDataMap output)
 {
+    filterMutex.lock();
     outputData = joinFilterDataMaps(outputData, output);
+    filterMutex.unlock();
 }
 
 void Filter::clearOutput(void)
 {
+    filterMutex.lock();
     outputData = filterDataMap();
+    filterMutex.unlock();
 }
 
 filterError Filter::updateBasedOnProfile(ProfileManager& pm, std::string name)

--- a/PMMain/Midas/MidasGUI/Filter.h
+++ b/PMMain/Midas/MidasGUI/Filter.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <map>
+#include <mutex>
 #include <boost/any.hpp>
 
 class ProfileManager;
@@ -183,6 +184,8 @@ private:
     filterDataMap outputData;
     filterStatus status;
     filterError error;
+
+    std::mutex filterMutex;
 };
 
 #endif FILTER_H

--- a/PMMain/Midas/MidasGUI/GenericAveragingFilter.cpp
+++ b/PMMain/Midas/MidasGUI/GenericAveragingFilter.cpp
@@ -19,6 +19,11 @@
 
 #include "GenericAveragingFilter.h"
 
+GenericAveragingFilter::~GenericAveragingFilter()
+{
+    int a = 1;
+}
+
 void GenericAveragingFilter::process()
 {
     filterDataMap input = Filter::getInput();

--- a/PMMain/Midas/MidasGUI/GenericAveragingFilter.h
+++ b/PMMain/Midas/MidasGUI/GenericAveragingFilter.h
@@ -34,7 +34,7 @@ class GenericAveragingFilter : public Filter
 public:
     /* Basic Construction/Destruction */
     GenericAveragingFilter(unsigned int avgCount, std::string inputMapKey) : avgCount(avgCount), inputMapKey(inputMapKey) {}
-    ~GenericAveragingFilter() {}
+    ~GenericAveragingFilter();
 
     /**
     * Access data from Inputs, average the data

--- a/PMMain/Midas/MidasGUI/GestureFilter.cpp
+++ b/PMMain/Midas/MidasGUI/GestureFilter.cpp
@@ -451,21 +451,17 @@ void GestureFilter::handleStateChange(CommandData response, GestureFilter *gf)
 filterDataMap GestureFilter::handleMouseCommand(CommandData response)
 {
 	filterDataMap outputToSharedCommandData;
-    if (controlStateHandle->getMode() == midasMode::MOUSE_MODE ||
-        controlStateHandle->getMode() == midasMode::MOUSE_MODE2 ||
-        controlStateHandle->getMode() == midasMode::GESTURE_MODE)
+
+    CommandData command;
+    command = response;
+
+    outputToSharedCommandData[COMMAND_INPUT] = command;
+    Filter::setOutput(outputToSharedCommandData);
+
+    buzzFeedbackMode bfm = settingsSignaller.getBuzzFeedbackMode();
+    if (bfm >= buzzFeedbackMode::ALLACTIONS)
     {
-        CommandData command;
-        command = response;
-
-        outputToSharedCommandData[COMMAND_INPUT] = command;
-        Filter::setOutput(outputToSharedCommandData);
-
-        buzzFeedbackMode bfm = settingsSignaller.getBuzzFeedbackMode();
-        if (bfm >= buzzFeedbackMode::ALLACTIONS)
-        {
-            myoStateHandle->peakMyo()->vibrateMyos(myo::Myo::VibrationType::vibrationShort);
-        }
+        myoStateHandle->peakMyo()->vibrateMyos(myo::Myo::VibrationType::vibrationShort);
     }
 	return outputToSharedCommandData;
 }

--- a/PMMain/Midas/MidasGUI/GestureFilter.cpp
+++ b/PMMain/Midas/MidasGUI/GestureFilter.cpp
@@ -43,9 +43,9 @@ GestureFilter::GestureFilter(ControlState* controlState, MyoState* myoState, clo
     imageManager.loadImages();
     gestSeqRecorder = new GestureSeqRecorder(controlState, mainGuiHandle, imageManager);
 
-    registerMouseSequences();
-    registerKeyboardSequences();
-    registerStateSequences();
+    defaultMouseSequences();
+    defaultKeyboardSequences();
+    defaultStateSequences();
 
     controlStateHandle = controlState;
 	myoStateHandle = myoState;
@@ -168,7 +168,7 @@ void GestureFilter::emitPoseData(int poseInt)
     }
 }
 
-void GestureFilter::registerMouseSequences(void)
+void GestureFilter::defaultMouseSequences(void)
 {
     // Register sequence to left click in mouse mode and gesture mode
     sequence clickSeq;
@@ -208,7 +208,7 @@ void GestureFilter::registerMouseSequences(void)
     }
 }
 
-void GestureFilter::registerKeyboardSequences(void)
+void GestureFilter::defaultKeyboardSequences(void)
 {
     sequence kybrdGUISequence;
     CommandData kybrdGUIResponse;
@@ -264,7 +264,7 @@ void GestureFilter::registerKeyboardSequences(void)
     }
 }
 
-void GestureFilter::registerStateSequences(void)
+void GestureFilter::defaultStateSequences(void)
 {
     // Register sequence from lock to Mouse Mode
     sequence lockToMouseSeq;

--- a/PMMain/Midas/MidasGUI/GestureFilter.h
+++ b/PMMain/Midas/MidasGUI/GestureFilter.h
@@ -106,19 +106,19 @@ private:
     * Performs initial registration of Mouse Sequences as a default incase profile manager
     * has no profiles to populate with.
     */
-    void registerMouseSequences(void);
+    void defaultMouseSequences(void);
 
     /**
     * Performs initial registration of Keyboard Sequences as a default incase profile manager
     * has no profiles to populate with.
     */
-    void registerKeyboardSequences(void);
+    void defaultKeyboardSequences(void);
 
     /**
     * Performs initial registration of State Sequences as a default incase profile manager
     * has no profiles to populate with.
     */
-    void registerStateSequences(void);
+    void defaultStateSequences(void);
 
     /**
     * Given a completed sequence, returning a CommandData response, this handles the response

--- a/PMMain/Midas/MidasGUI/GestureHoldModeAction.cpp
+++ b/PMMain/Midas/MidasGUI/GestureHoldModeAction.cpp
@@ -20,6 +20,7 @@
 #include "GestureHoldModeAction.h"
 
 GestureHoldModeAction::GestureHoldModeAction() {
+    rollSensitivity = 1; pitchSensitivity = 1; yawSensitivity = 1;
 }
 
 GestureHoldModeAction::GestureHoldModeAction(float rollSensitivity, float pitchSensitivity, float yawSensitivity) : 

--- a/PMMain/Midas/MidasGUI/GestureHoldModeAction.cpp
+++ b/PMMain/Midas/MidasGUI/GestureHoldModeAction.cpp
@@ -19,13 +19,12 @@
 
 #include "GestureHoldModeAction.h"
 
-GestureHoldModeAction::GestureHoldModeAction() : minIntervalLen(50) {
-
+GestureHoldModeAction::GestureHoldModeAction() {
 }
 
-GestureHoldModeAction::GestureHoldModeAction(unsigned int minIntervalLen) : minIntervalLen(minIntervalLen) {
-
-}
+GestureHoldModeAction::GestureHoldModeAction(float rollSensitivity, float pitchSensitivity, float yawSensitivity) : 
+    rollSensitivity(rollSensitivity), pitchSensitivity(pitchSensitivity), yawSensitivity(yawSensitivity)
+{}
 
 void GestureHoldModeAction::clearMap()
 {

--- a/PMMain/Midas/MidasGUI/GestureHoldModeAction.cpp
+++ b/PMMain/Midas/MidasGUI/GestureHoldModeAction.cpp
@@ -20,16 +20,25 @@
 #include "GestureHoldModeAction.h"
 
 GestureHoldModeAction::GestureHoldModeAction() {
-    rollSensitivity = 1; pitchSensitivity = 1; yawSensitivity = 1;
+    rollSensitivity = DEFAULT_SENSITIVITY; pitchSensitivity = DEFAULT_SENSITIVITY; yawSensitivity = DEFAULT_SENSITIVITY;
+    actionType = DEFAULT_ACTION_TYPE;
+    intervalLen = DEFAULT_INTERVAL_LEN;
+    velocityIntervalLen = DEFAULT_INTERVAL_LEN;
 }
 
 GestureHoldModeAction::GestureHoldModeAction(float rollSensitivity, float pitchSensitivity, float yawSensitivity) : 
     rollSensitivity(rollSensitivity), pitchSensitivity(pitchSensitivity), yawSensitivity(yawSensitivity)
 {}
 
-void GestureHoldModeAction::clearMap()
+void GestureHoldModeAction::clean()
 {
     actionMap.clear();
+    actionType = DEFAULT_ACTION_TYPE;
+    intervalLen = DEFAULT_INTERVAL_LEN;
+    velocityIntervalLen = DEFAULT_INTERVAL_LEN;
+    rollSensitivity = DEFAULT_SENSITIVITY;
+    pitchSensitivity = DEFAULT_SENSITIVITY;
+    yawSensitivity = DEFAULT_SENSITIVITY;
 }
 
 bool GestureHoldModeAction::addToActionMap(angleData ad, kybdCmds command)

--- a/PMMain/Midas/MidasGUI/GestureHoldModeAction.h
+++ b/PMMain/Midas/MidasGUI/GestureHoldModeAction.h
@@ -47,6 +47,18 @@ typedef struct angleData {
         PITCH,
         YAW
     };
+
+    angleData()
+    {
+        angleType = ROLL;
+        anglePositive = true;
+    }
+    angleData(AngleType type, bool positive)
+    {
+        angleType = type;
+        anglePositive = positive;
+    }
+
     AngleType angleType;
     bool anglePositive;
 } angleData;
@@ -54,7 +66,7 @@ typedef struct angleData {
 class GestureHoldModeAction {
 public:
     GestureHoldModeAction();
-    GestureHoldModeAction(unsigned int minIntervalLen);
+    GestureHoldModeAction(float rollSensitivity, float pitchSensitivity, float yawSensitivity);
 
     void clearMap();
 
@@ -62,18 +74,23 @@ public:
 
     kybdCmds getAction(angleData ad);
 
+    void setRollSensitivity(float sensitivity) { rollSensitivity = sensitivity; }
+    float getRollSensitivity() { return rollSensitivity; }
+
+    void setPitchSensitivity(float sensitivity) { pitchSensitivity = sensitivity; }
+    float getPitchSensitivity() { return pitchSensitivity; }
+
+    void setYawSensitivity(float sensitivity) { yawSensitivity = sensitivity; }
+    float getYawSensitivity() { return yawSensitivity; }
+
 private:
-    // TODO - actually care about this type. In the meantime, coding Interval_delta since it's easiest.
-    // enum holdModeActionType {
-    //     INTERVAL_DELTA, // if in a given interval a signal is +/-, an action will ensue
-    //     ABSOLUTE_DELTA_NUM_SIGS, // Based on the delta, ensure the number of +/- actions is at a certain value (repeatable change)
-    //     ABSOLUTE_DELTA_VELOCITY // Based on delta, continue spewing actions
-    // };
+    // Sensitivities indicate how many DEGREES are required to trigger ONE action
+    // (stored in the actionMap)
+    float rollSensitivity;
+    float pitchSensitivity;
+    float yawSensitivity;
 
-    std::unordered_map<int, kybdCmds> actionMap;
-
-    unsigned int minIntervalLen; // between sampling signals and sending actions // TODO - make this useful
-    
+    std::unordered_map<int, kybdCmds> actionMap;    
 };
 
 #endif /* GESTURE_HOLD_MODE_ACTION_HPP */

--- a/PMMain/Midas/MidasGUI/GestureHoldModeAction.h
+++ b/PMMain/Midas/MidasGUI/GestureHoldModeAction.h
@@ -83,12 +83,31 @@ public:
     void setYawSensitivity(float sensitivity) { yawSensitivity = sensitivity; }
     float getYawSensitivity() { return yawSensitivity; }
 
+    void setActionType(HoldModeActionType type) { actionType = type; }
+    HoldModeActionType getActionType() { return actionType; }
+
+    void setIntervalLen(unsigned int len) { intervalLen = len; }
+    unsigned int getIntervalLen() { return intervalLen; }
+
+    void setVelocityIntervalLen(unsigned int len) { velocityIntervalLen = len; }
+    unsigned int getVelocityIntervalLen() { return velocityIntervalLen; }
+
 private:
     // Sensitivities indicate how many DEGREES are required to trigger ONE action
     // (stored in the actionMap)
     float rollSensitivity;
     float pitchSensitivity;
     float yawSensitivity;
+
+    // defines functionality for observer
+    HoldModeActionType actionType;
+
+    // Vars required for INTERVAL_DELTA mode
+    unsigned int intervalLen;
+    unsigned int currIntervalCount;
+    // Vars required for ABS_DELTA_VELOCITY mode
+    unsigned int velocityIntervalLen;
+    unsigned int velocityCurrIntervalCount;
 
     std::unordered_map<int, kybdCmds> actionMap;    
 };

--- a/PMMain/Midas/MidasGUI/GestureHoldModeAction.h
+++ b/PMMain/Midas/MidasGUI/GestureHoldModeAction.h
@@ -23,6 +23,10 @@
 #include "MidasCommon.h"
 #include <unordered_map>
 
+#define DEFAULT_SENSITIVITY 1
+#define DEFAULT_INTERVAL_LEN 100
+#define DEFAULT_ACTION_TYPE HoldModeActionType::ABS_DELTA_FINITE
+
 typedef struct angleData {
     bool operator==(const angleData& ad)
     {
@@ -68,7 +72,7 @@ public:
     GestureHoldModeAction();
     GestureHoldModeAction(float rollSensitivity, float pitchSensitivity, float yawSensitivity);
 
-    void clearMap();
+    void clean();
 
     bool addToActionMap(angleData ad, kybdCmds command);
 
@@ -104,10 +108,8 @@ private:
 
     // Vars required for INTERVAL_DELTA mode
     unsigned int intervalLen;
-    unsigned int currIntervalCount;
     // Vars required for ABS_DELTA_VELOCITY mode
     unsigned int velocityIntervalLen;
-    unsigned int velocityCurrIntervalCount;
 
     std::unordered_map<int, kybdCmds> actionMap;    
 };

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
@@ -167,6 +167,8 @@ void HoldModeObserver::handleAbsDeltaVelocity()
 {
     if (velocityCurrIntervalCount >= actions->getVelocityIntervalLen())
     {
+        velocityCurrIntervalCount = 0;
+
         float deltaRollDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentRoll(), BaseMeasurements::getInstance().getBaseRoll()));
         float deltaPitchDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentPitch(), BaseMeasurements::getInstance().getBasePitch()));
         float deltaYawDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentYaw(), BaseMeasurements::getInstance().getBaseYaw()));
@@ -184,7 +186,7 @@ void HoldModeObserver::handleAbsDeltaVelocity()
     }
     else
     {
-        currIntervalCount += callbackPeriod;
+        velocityCurrIntervalCount += callbackPeriod;
     }
 }
 

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
@@ -1,0 +1,168 @@
+/*
+    Copyright (C) 2015 Midas
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+    USA
+*/
+
+#include "HoldModeObserver.h"
+#include "MyoState.h"
+#include "BaseMeasurements.h"
+#include "MyoTranslationFilter.h"
+#include "SharedCommandData.h"
+#include "AdvancedFilterPipeline.h"
+#include "FilterKeys.h"
+#include <thread>
+
+HoldModeObserver::HoldModeObserver()
+{
+
+}
+
+HoldModeObserver::HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod, HoldModeActionType actionType, unsigned int intervalLen, unsigned int velocityIntervalLen) :
+    sharedCommandDataHandle(scd), myoStateHandle(myoState), actions(actions), callbackPeriod(callbackPeriod), actionType(actionType),
+    intervalLen(intervalLen), currIntervalCount(0), velocityIntervalLen(velocityIntervalLen), velocityCurrIntervalCount(0),
+    currRollExecuted(0), currPitchExecuted(0), currYawExecuted(0)
+{
+    prevRoll  = BaseMeasurements::getInstance().getCurrentRoll();
+    prevPitch = BaseMeasurements::getInstance().getCurrentPitch();
+    prevYaw   = BaseMeasurements::getInstance().getCurrentYaw();
+}
+
+void HoldModeObserver::kickOffObserver()
+{
+    // setup callback thread that uses 'this" as 'this'
+    std::thread callbackThread(&HoldModeObserver::observerThread, this);
+    callbackThread.detach();
+}
+
+void HoldModeObserver::observerThread()
+{
+    std::chrono::milliseconds period(callbackPeriod);
+    do {
+        std::this_thread::sleep_for(period);
+        
+        // TODO do stuff
+        switch (actionType)
+        {
+        case INTERVAL_DELTA:
+            handleIntervalDelta();
+            break;
+        case ABS_DELTA_FINITE:
+            handleAbsDeltaFinite();
+            break;
+        case ABS_DELTA_VELOCITY:
+            handleAbsDeltaVelocity();
+            break;
+        default:
+            break;
+        }
+
+        prevRoll = BaseMeasurements::getInstance().getCurrentRoll();
+        prevPitch = BaseMeasurements::getInstance().getCurrentPitch();
+        prevYaw = BaseMeasurements::getInstance().getCurrentYaw();
+    } while (true);
+}
+
+void HoldModeObserver::handleIntervalDelta()
+{
+    float deltaRollDeg  = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentRoll() , prevRoll));
+    float deltaPitchDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentPitch(), prevPitch));
+    float deltaYawDeg   = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentYaw(), prevYaw));
+    
+    int rollTicks = deltaRollDeg / actions->getRollSensitivity();
+    int pitchTicks = deltaPitchDeg / actions->getPitchSensitivity();
+    int yawTicks = deltaYawDeg / actions->getYawSensitivity();
+    
+    // if 0, will return associated negative cmd, but wont be executed (so its safe).
+    kybdCmds rollCmd = actions->getAction(angleData(angleData::AngleType::ROLL, rollTicks > 0));
+    kybdCmds pitchCmd = actions->getAction(angleData(angleData::AngleType::PITCH, pitchTicks > 0));
+    kybdCmds yawCmd = actions->getAction(angleData(angleData::AngleType::YAW, yawTicks > 0));
+
+    executeCommands(rollCmd, abs(rollTicks), pitchCmd, abs(pitchTicks), yawCmd, abs(yawTicks));
+}
+
+void HoldModeObserver::handleAbsDeltaFinite()
+{
+    float deltaRollDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentRoll(), BaseMeasurements::getInstance().getBaseRoll()));
+    float deltaPitchDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentPitch(), BaseMeasurements::getInstance().getBasePitch()));
+    float deltaYawDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentYaw(), BaseMeasurements::getInstance().getBaseYaw()));
+
+    // TODO - decide if this is a better method - this way will send (repeatably) the number of ticks all at once on each interval,
+    // but may be too fast? -- Alternative is to only send ONE cmd per interval and modify the currXXXExecuted vars iteratively. That was initial design, but 
+    // tryin this for now...
+    int rollTicks =  (deltaRollDeg / actions->getRollSensitivity())   - currRollExecuted;
+    int pitchTicks = (deltaPitchDeg / actions->getPitchSensitivity()) - currPitchExecuted;
+    int yawTicks =   (deltaYawDeg / actions->getYawSensitivity())     - currYawExecuted;
+
+    // if 0, will return associated negative cmd, but wont be executed (so its safe).
+    kybdCmds rollCmd = actions->getAction(angleData(angleData::AngleType::ROLL, rollTicks > 0));
+    kybdCmds pitchCmd = actions->getAction(angleData(angleData::AngleType::PITCH, pitchTicks > 0));
+    kybdCmds yawCmd = actions->getAction(angleData(angleData::AngleType::YAW, yawTicks > 0));
+
+    executeCommands(rollCmd, abs(rollTicks), pitchCmd, abs(pitchTicks), yawCmd, abs(yawTicks));
+
+    currRollExecuted = (deltaRollDeg / actions->getRollSensitivity());
+    currPitchExecuted = (deltaPitchDeg / actions->getPitchSensitivity());
+    currYawExecuted = (deltaYawDeg / actions->getYawSensitivity());
+}
+
+void HoldModeObserver::handleAbsDeltaVelocity()
+{
+    float deltaRollDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentRoll(), BaseMeasurements::getInstance().getBaseRoll()));
+    float deltaPitchDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentPitch(), BaseMeasurements::getInstance().getBasePitch()));
+    float deltaYawDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentYaw(), BaseMeasurements::getInstance().getBaseYaw()));
+    
+    int rollTicks = deltaRollDeg / actions->getRollSensitivity();
+    int pitchTicks = deltaPitchDeg / actions->getPitchSensitivity();
+    int yawTicks = deltaYawDeg / actions->getYawSensitivity();
+    
+    // if 0, will return associated negative cmd, but wont be executed (so its safe).
+    kybdCmds rollCmd = actions->getAction(angleData(angleData::AngleType::ROLL, rollTicks > 0));
+    kybdCmds pitchCmd = actions->getAction(angleData(angleData::AngleType::PITCH, pitchTicks > 0));
+    kybdCmds yawCmd = actions->getAction(angleData(angleData::AngleType::YAW, yawTicks > 0));
+    
+    executeCommands(rollCmd, abs(rollTicks), pitchCmd, abs(pitchTicks), yawCmd, abs(yawTicks));
+}
+
+void HoldModeObserver::executeCommands(kybdCmds rollCmd, unsigned int rollTicks, kybdCmds pitchCmd, unsigned int pitchTicks, kybdCmds yawCmd, unsigned int yawTicks)
+{
+    AdvancedFilterPipeline pipe;
+    pipe.registerFilterAtDeepestLevel(sharedCommandDataHandle);
+    CommandData cmd;
+    cmd.type = commandType::KYBRD_CMD;
+    cmd.name = "Hold Command";
+    for (int i = 0; i < rollTicks && rollCmd != kybdCmds::NO_CMD; i++)
+    {
+        filterDataMap input;
+        cmd.action.kybd = rollCmd;
+        input[COMMAND_INPUT] = cmd;
+        pipe.startPipeline(input);
+    }
+    for (int i = 0; i < pitchTicks && pitchCmd != kybdCmds::NO_CMD; i++)
+    {
+        filterDataMap input;
+        cmd.action.kybd = pitchCmd;
+        input[COMMAND_INPUT] = cmd;
+        pipe.startPipeline(input);
+    }
+    for (int i = 0; i < yawTicks && yawCmd != kybdCmds::NO_CMD; i++)
+    {
+        filterDataMap input;
+        cmd.action.kybd = yawCmd;
+        input[COMMAND_INPUT] = cmd;
+        pipe.startPipeline(input);
+    }
+}

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
@@ -28,7 +28,11 @@
 
 HoldModeObserver::HoldModeObserver()
 {
+    commitSuicide = false;
+}
 
+HoldModeObserver::~HoldModeObserver()
+{
 }
 
 HoldModeObserver::HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod, HoldModeActionType actionType, unsigned int intervalLen, unsigned int velocityIntervalLen) :
@@ -39,6 +43,7 @@ HoldModeObserver::HoldModeObserver(MyoState* myoState, SharedCommandData* scd, G
     prevRoll  = BaseMeasurements::getInstance().getCurrentRoll();
     prevPitch = BaseMeasurements::getInstance().getCurrentPitch();
     prevYaw   = BaseMeasurements::getInstance().getCurrentYaw();
+    commitSuicide = false;
 }
 
 void HoldModeObserver::kickOffObserver()
@@ -54,6 +59,8 @@ void HoldModeObserver::observerThread()
     do {
         std::this_thread::sleep_for(period);
         
+        if (commitSuicide)
+            break;
         // TODO do stuff
         switch (actionType)
         {
@@ -74,6 +81,8 @@ void HoldModeObserver::observerThread()
         prevPitch = BaseMeasurements::getInstance().getCurrentPitch();
         prevYaw = BaseMeasurements::getInstance().getCurrentYaw();
     } while (true);
+
+    delete this;
 }
 
 void HoldModeObserver::handleIntervalDelta()
@@ -96,11 +105,6 @@ void HoldModeObserver::handleIntervalDelta()
 
 void HoldModeObserver::handleAbsDeltaFinite()
 {
-    // TODO - REMOVE! This is TEMP
-    if (myoStateHandle->mostRecentPose() != myo::Pose::fist)
-    {
-        return;
-    }
     float deltaRollDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentRoll(), BaseMeasurements::getInstance().getBaseRoll()));
     float deltaPitchDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentPitch(), BaseMeasurements::getInstance().getBasePitch()));
     float deltaYawDeg = MyoTranslationFilter::radToDeg(MyoTranslationFilter::calcRingDelta(BaseMeasurements::getInstance().getCurrentYaw(), BaseMeasurements::getInstance().getBaseYaw()));

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.cpp
@@ -36,8 +36,8 @@ HoldModeObserver::~HoldModeObserver()
 }
 
 HoldModeObserver::HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod, HoldModeActionType actionType, unsigned int intervalLen, unsigned int velocityIntervalLen) :
-    sharedCommandDataHandle(scd), myoStateHandle(myoState), actions(actions), callbackPeriod(callbackPeriod), actionType(actionType),
-    intervalLen(intervalLen), currIntervalCount(0), velocityIntervalLen(velocityIntervalLen), velocityCurrIntervalCount(0),
+    sharedCommandDataHandle(scd), myoStateHandle(myoState), actions(actions), callbackPeriod(callbackPeriod), currIntervalCount(0), velocityCurrIntervalCount(0), 
+    // actionType(actionType), intervalLen(intervalLen),  velocityIntervalLen(velocityIntervalLen), 
     currRollExecuted(0), currPitchExecuted(0), currYawExecuted(0)
 {
     prevRoll  = BaseMeasurements::getInstance().getCurrentRoll();
@@ -62,7 +62,7 @@ void HoldModeObserver::observerThread()
         if (commitSuicide)
             break;
         // TODO do stuff
-        switch (actionType)
+        switch (actions->getActionType())
         {
         case INTERVAL_DELTA:
             handleIntervalDelta();

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.h
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.h
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2015 Midas
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+    USA
+*/
+
+#ifndef HOLD_MODE_OBSERVER_H
+#define HOLD_MODE_OBSERVER_H
+
+#include "MidasCommon.h"
+
+#define DEFAULT_CALLBACK_PER 20
+#define DEFAULT_INTERVAL_LEN 100
+#define DEFAULT_ACTION_TYPE HoldModeActionType::ABS_DELTA_FINITE
+
+class MyoState;
+class GestureHoldModeAction;
+class SharedCommandData;
+
+class HoldModeObserver {
+public:
+    enum HoldModeActionType {
+        INTERVAL_DELTA, // if in a given interval an angle is +/- beyond a threshold, >=1 action will ensue 
+        ABS_DELTA_FINITE, // Based on the net delta beyond threshold, ensure the number of +/- actions is at a certain value (repeatable change)
+        ABS_DELTA_VELOCITY // Based on net delta beyond threshold, continue spewing actions
+    };
+
+    HoldModeObserver();
+    HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod = DEFAULT_CALLBACK_PER, HoldModeActionType actionType = DEFAULT_ACTION_TYPE,
+        unsigned int intervalLen = DEFAULT_INTERVAL_LEN, unsigned int velocityIntervalLen = DEFAULT_INTERVAL_LEN);
+
+    void kickOffObserver();
+
+    void setCallbackPeriod(unsigned int callbackPeriod) { this->callbackPeriod = callbackPeriod; }
+    unsigned int getCallbackPeriod() { return callbackPeriod; }
+
+    void setActionType(HoldModeActionType type) { actionType = type; }
+    HoldModeActionType getActionType() { return actionType; }
+
+    void setIntervalLen(unsigned int len) { intervalLen = len; }
+    unsigned int getIntervalLen() { return intervalLen; }
+
+    void setVelocityIntervalLen(unsigned int len) { velocityIntervalLen = len; }
+    unsigned int getVelocityIntervalLen() { return velocityIntervalLen; }
+
+private:
+    // Thread with main logic of observer, alive for state duration,
+    // with execution defined by callbackPeriod
+    void observerThread();
+
+    void handleIntervalDelta();
+    void handleAbsDeltaFinite();
+    void handleAbsDeltaVelocity();
+
+    void executeCommands(kybdCmds rollCmd, unsigned int rollTicks, kybdCmds pitchCmd, unsigned int pitchTicks, kybdCmds yawCmd, unsigned int yawTicks);
+
+    float prevRoll;
+    float prevPitch;
+    float prevYaw;
+
+    MyoState* myoStateHandle;
+
+    SharedCommandData* sharedCommandDataHandle;
+
+    // defines frequency of observer.
+    unsigned int callbackPeriod;
+
+    // defines functionality of observer
+    HoldModeActionType actionType;
+    
+    // defines actions of observer
+    GestureHoldModeAction* actions; // not owned
+
+    // Vars required for INTERVAL_DELTA mode
+    unsigned int intervalLen;
+    unsigned int currIntervalCount;
+
+    // Vars required for ABS_DELTA_FINITE mode
+    // Executed counts can be + or -, indicating how many actions associated with each angle type have been executed.
+    int currRollExecuted; 
+    int currPitchExecuted; 
+    int currYawExecuted; 
+
+    // Vars required for ABS_DELTA_VELOCITY mode
+    unsigned int velocityIntervalLen;
+    unsigned int velocityCurrIntervalCount;
+};
+
+#endif

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.h
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.h
@@ -42,14 +42,14 @@ public:
     void setCallbackPeriod(unsigned int callbackPeriod) { this->callbackPeriod = callbackPeriod; }
     unsigned int getCallbackPeriod() { return callbackPeriod; }
 
-    void setActionType(HoldModeActionType type) { actionType = type; }
-    HoldModeActionType getActionType() { return actionType; }
-
-    void setIntervalLen(unsigned int len) { intervalLen = len; }
-    unsigned int getIntervalLen() { return intervalLen; }
-
-    void setVelocityIntervalLen(unsigned int len) { velocityIntervalLen = len; }
-    unsigned int getVelocityIntervalLen() { return velocityIntervalLen; }
+//    void setActionType(HoldModeActionType type) { actionType = type; }
+//    HoldModeActionType getActionType() { return actionType; }
+//
+//    void setIntervalLen(unsigned int len) { intervalLen = len; }
+//    unsigned int getIntervalLen() { return intervalLen; }
+//
+//    void setVelocityIntervalLen(unsigned int len) { velocityIntervalLen = len; }
+//    unsigned int getVelocityIntervalLen() { return velocityIntervalLen; }
 
     void kill() { commitSuicide = true; }
 
@@ -75,14 +75,14 @@ private:
     // defines frequency of observer.
     unsigned int callbackPeriod;
 
-    // defines functionality of observer
-    HoldModeActionType actionType;
+//    // defines functionality of observer
+//    HoldModeActionType actionType;
     
     // defines actions of observer
     GestureHoldModeAction* actions; // not owned
 
-    // Vars required for INTERVAL_DELTA mode
-    unsigned int intervalLen;
+//    // Vars required for INTERVAL_DELTA mode
+//    unsigned int intervalLen;
     unsigned int currIntervalCount;
 
     // Vars required for ABS_DELTA_FINITE mode
@@ -91,8 +91,8 @@ private:
     int currPitchExecuted; 
     int currYawExecuted; 
 
-    // Vars required for ABS_DELTA_VELOCITY mode
-    unsigned int velocityIntervalLen;
+//    // Vars required for ABS_DELTA_VELOCITY mode
+//    unsigned int velocityIntervalLen;
     unsigned int velocityCurrIntervalCount;
 
     // used to stop thread

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.h
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.h
@@ -32,12 +32,6 @@ class SharedCommandData;
 
 class HoldModeObserver {
 public:
-    enum HoldModeActionType {
-        INTERVAL_DELTA, // if in a given interval an angle is +/- beyond a threshold, >=1 action will ensue 
-        ABS_DELTA_FINITE, // Based on the net delta beyond threshold, ensure the number of +/- actions is at a certain value (repeatable change)
-        ABS_DELTA_VELOCITY // Based on net delta beyond threshold, continue spewing actions
-    };
-
     HoldModeObserver();
     HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod = DEFAULT_CALLBACK_PER, HoldModeActionType actionType = DEFAULT_ACTION_TYPE,
         unsigned int intervalLen = DEFAULT_INTERVAL_LEN, unsigned int velocityIntervalLen = DEFAULT_INTERVAL_LEN);

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.h
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.h
@@ -39,15 +39,6 @@ public:
     void setCallbackPeriod(unsigned int callbackPeriod) { this->callbackPeriod = callbackPeriod; }
     unsigned int getCallbackPeriod() { return callbackPeriod; }
 
-//    void setActionType(HoldModeActionType type) { actionType = type; }
-//    HoldModeActionType getActionType() { return actionType; }
-//
-//    void setIntervalLen(unsigned int len) { intervalLen = len; }
-//    unsigned int getIntervalLen() { return intervalLen; }
-//
-//    void setVelocityIntervalLen(unsigned int len) { velocityIntervalLen = len; }
-//    unsigned int getVelocityIntervalLen() { return velocityIntervalLen; }
-
     void kill() { commitSuicide = true; }
 
 private:
@@ -72,14 +63,10 @@ private:
     // defines frequency of observer.
     unsigned int callbackPeriod;
 
-//    // defines functionality of observer
-//    HoldModeActionType actionType;
-    
     // defines actions of observer
     GestureHoldModeAction* actions; // not owned
 
-//    // Vars required for INTERVAL_DELTA mode
-//    unsigned int intervalLen;
+    // Vars required for INTERVAL_DELTA mode
     unsigned int currIntervalCount;
 
     // Vars required for ABS_DELTA_FINITE mode
@@ -88,8 +75,7 @@ private:
     int currPitchExecuted; 
     int currYawExecuted; 
 
-//    // Vars required for ABS_DELTA_VELOCITY mode
-//    unsigned int velocityIntervalLen;
+    // Vars required for ABS_DELTA_VELOCITY mode
     unsigned int velocityCurrIntervalCount;
 
     // used to stop thread

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.h
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.h
@@ -41,6 +41,7 @@ public:
     HoldModeObserver();
     HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod = DEFAULT_CALLBACK_PER, HoldModeActionType actionType = DEFAULT_ACTION_TYPE,
         unsigned int intervalLen = DEFAULT_INTERVAL_LEN, unsigned int velocityIntervalLen = DEFAULT_INTERVAL_LEN);
+    ~HoldModeObserver();
 
     void kickOffObserver();
 
@@ -55,6 +56,8 @@ public:
 
     void setVelocityIntervalLen(unsigned int len) { velocityIntervalLen = len; }
     unsigned int getVelocityIntervalLen() { return velocityIntervalLen; }
+
+    void kill() { commitSuicide = true; }
 
 private:
     // Thread with main logic of observer, alive for state duration,
@@ -97,6 +100,9 @@ private:
     // Vars required for ABS_DELTA_VELOCITY mode
     unsigned int velocityIntervalLen;
     unsigned int velocityCurrIntervalCount;
+
+    // used to stop thread
+    bool commitSuicide;
 };
 
 #endif

--- a/PMMain/Midas/MidasGUI/HoldModeObserver.h
+++ b/PMMain/Midas/MidasGUI/HoldModeObserver.h
@@ -22,9 +22,7 @@
 
 #include "MidasCommon.h"
 
-#define DEFAULT_CALLBACK_PER 20
-#define DEFAULT_INTERVAL_LEN 100
-#define DEFAULT_ACTION_TYPE HoldModeActionType::ABS_DELTA_FINITE
+#define DEFAULT_CALLBACK_PER 50
 
 class MyoState;
 class GestureHoldModeAction;
@@ -33,8 +31,7 @@ class SharedCommandData;
 class HoldModeObserver {
 public:
     HoldModeObserver();
-    HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod = DEFAULT_CALLBACK_PER, HoldModeActionType actionType = DEFAULT_ACTION_TYPE,
-        unsigned int intervalLen = DEFAULT_INTERVAL_LEN, unsigned int velocityIntervalLen = DEFAULT_INTERVAL_LEN);
+    HoldModeObserver(MyoState* myoState, SharedCommandData* scd, GestureHoldModeAction* actions, unsigned int callbackPeriod = DEFAULT_CALLBACK_PER);
     ~HoldModeObserver();
 
     void kickOffObserver();

--- a/PMMain/Midas/MidasGUI/MidasCommon.h
+++ b/PMMain/Midas/MidasGUI/MidasCommon.h
@@ -246,4 +246,10 @@ struct keyboardAngle {
     int x, y;
 };
 
+enum HoldModeActionType {
+    ABS_DELTA_FINITE, // Based on the net delta beyond threshold, ensure the number of +/- actions is at a certain value (repeatable change)
+    ABS_DELTA_VELOCITY, // Based on net delta beyond threshold, continue spewing actions
+    INTERVAL_DELTA // if in a given interval an angle is +/- beyond a threshold, >=1 action will ensue 
+};
+
 #endif /* _MIDAS_COMMON_H */

--- a/PMMain/Midas/MidasGUI/MidasGUI.vcxproj
+++ b/PMMain/Midas/MidasGUI/MidasGUI.vcxproj
@@ -204,6 +204,7 @@
     <ClCompile Include="GestureHoldModeAction.cpp" />
     <ClCompile Include="GestureSeqRecorder.cpp" />
     <ClCompile Include="GestureSignaller.cpp" />
+    <ClCompile Include="HoldModeObserver.cpp" />
     <ClCompile Include="InfoIndicator.cpp" />
     <ClCompile Include="KeyboardController.cpp" />
     <ClCompile Include="KeyboardSettingsReader.cpp" />
@@ -300,6 +301,7 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB "-I.\GeneratedFiles" "-I." "-I$(QTDIR)\include" "-I.\GeneratedFiles\$(ConfigurationName)\." "-I$(QTDIR)\include\QtCore" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtWidgets"</Command>
     </CustomBuild>
+    <ClInclude Include="HoldModeObserver.h" />
     <ClInclude Include="KeyboardContoller.h" />
     <ClInclude Include="KeyboardSettingsReader.h" />
     <ClInclude Include="KeyboardVector.h" />

--- a/PMMain/Midas/MidasGUI/MidasGUI.vcxproj.filters
+++ b/PMMain/Midas/MidasGUI/MidasGUI.vcxproj.filters
@@ -299,6 +299,9 @@
     <ClCompile Include="GenericBypassFilter.cpp">
       <Filter>Source Files\Midas\Filters</Filter>
     </ClCompile>
+    <ClCompile Include="HoldModeObserver.cpp">
+      <Filter>Source Files\Midas</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="MidasThread.h">
@@ -434,6 +437,9 @@
     </ClInclude>
     <ClInclude Include="GenericBypassFilter.h">
       <Filter>Header Files\Midas\Filters</Filter>
+    </ClInclude>
+    <ClInclude Include="HoldModeObserver.h">
+      <Filter>Header Files\Midas</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/PMMain/Midas/MidasGUI/MidasMain.cpp
+++ b/PMMain/Midas/MidasGUI/MidasMain.cpp
@@ -138,7 +138,8 @@ int midasMain(MidasThread *threadHandle, MainGUI *mainGui, ProfileManager *pm) {
 
     while (true)
     {
-        if (myoDevice->getDeviceStatus() != deviceStatus::RUNNING) break;
+        if (myoDevice->getDeviceStatus() != deviceStatus::RUNNING) 
+            break;
 
         scdDigester.digest();
     }

--- a/PMMain/Midas/MidasGUI/MouseCtrl.cpp
+++ b/PMMain/Midas/MidasGUI/MouseCtrl.cpp
@@ -30,7 +30,7 @@ MouseCtrl::MouseCtrl()
     lastMouseScroll = lastMouseMoveX;
     minMoveXTimeDelta = DEFAULT_MIN_MOVE_TIME;
     minMoveYTimeDelta = DEFAULT_MIN_MOVE_TIME;
-    scrollRate = DEFAULT_SCROLL_RATE;
+    scrollRate = WHEEL_DELTA;
     currHeld = 0;
 }
 
@@ -42,7 +42,7 @@ void MouseCtrl::setScrollRate(int rate)
 {
     if (rate < -WHEEL_DELTA || rate > WHEEL_DELTA)
     {
-        scrollRate = DEFAULT_SCROLL_RATE; 
+        scrollRate = WHEEL_DELTA;
     } 
     else
     {
@@ -282,11 +282,11 @@ void MouseCtrl::setMouseInputVars(mouseCmds mouseCmd, double& mouseRateIfMove, d
         break;
     case mouseCmds::SCROLL_UP:
         mi.dwFlags = MOUSEEVENTF_WHEEL;
-        mi.mouseData = scrollRate; // RANGE IS FROM -120 to +120 : WHEEL_DELTA = 120, which is one "wheel click"
+        mi.mouseData = abs(scrollRate); // RANGE IS FROM -120 to +120 : WHEEL_DELTA = 120, which is one "wheel click"
         break;
     case mouseCmds::SCROLL_DOWN:
         mi.dwFlags = MOUSEEVENTF_WHEEL;
-        mi.mouseData = -scrollRate; // RANGE IS FROM -120 to +120 : WHEEL_DELTA = 120, which is one "wheel click"
+        mi.mouseData = -abs(scrollRate); // RANGE IS FROM -120 to +120 : WHEEL_DELTA = 120, which is one "wheel click"
         break;
 	case mouseCmds::MOVE_ABSOLUTE:
 		if (!BaseMeasurements::getInstance().areCurrentValuesValid())

--- a/PMMain/Midas/MidasGUI/MouseCtrl.h
+++ b/PMMain/Midas/MidasGUI/MouseCtrl.h
@@ -26,7 +26,6 @@
 #include "MidasCommon.h"
 
 #define DEFAULT_MIN_MOVE_TIME 10
-#define DEFAULT_SCROLL_RATE 1 //Default to slow rate.
 #define SCROLL_MIN_TIME 5
 #define MAX_MOVE_TIME_DELTA 40 //large enough ms delay between moving a pixel is pretty slow.
 #define MIN_MOVE_TIME_DELTA 1 //small enough ms delay between moving a pixel is fast, but not uncontrolled..

--- a/PMMain/Midas/MidasGUI/MyoCommon.h
+++ b/PMMain/Midas/MidasGUI/MyoCommon.h
@@ -153,41 +153,4 @@ static std::string buzzFeedbackModeToString(buzzFeedbackMode bfm)
     }
 }
 
-static midasMode myoPoseToMidasHoldMode(myo::Pose pose)
-{
-    switch (pose.type())
-    {
-    case Pose::doubleTap:
-        return GESTURE_HOLD_ONE;
-    case Pose::fingersSpread:
-        return GESTURE_HOLD_TWO;
-    case Pose::fist:
-        return GESTURE_HOLD_THREE;
-    case Pose::waveIn:
-        return GESTURE_HOLD_FOUR;
-    case Pose::waveOut:
-        return GESTURE_HOLD_FIVE;
-    default:
-        return GESTURE_HOLD_FIVE;
-    }
-}
-
-static myo::Pose midasHoldModeToMyoPose(midasMode holdMode)
-{
-    switch (holdMode)
-    {
-    case GESTURE_HOLD_ONE:
-        return Pose::doubleTap;
-    case GESTURE_HOLD_TWO:
-        return Pose::fingersSpread;
-    case GESTURE_HOLD_THREE:
-        return Pose::fist;
-    case GESTURE_HOLD_FOUR:
-        return Pose::waveIn;
-    case GESTURE_HOLD_FIVE:
-        return Pose::waveOut;
-    default:
-        return Pose::waveOut;
-    }
-}
 #endif /* _MYO_COMMON_H */

--- a/PMMain/Midas/MidasGUI/MyoCommon.h
+++ b/PMMain/Midas/MidasGUI/MyoCommon.h
@@ -21,6 +21,7 @@
 #define _MYO_COMMON_H
 
 #include "myo\myo.hpp"
+#include "MidasCommon.h"
 #include <qpixmap.h>
 
 #define CENTER_MAIN "Space"
@@ -152,4 +153,41 @@ static std::string buzzFeedbackModeToString(buzzFeedbackMode bfm)
     }
 }
 
+static midasMode myoPoseToMidasHoldMode(myo::Pose pose)
+{
+    switch (pose.type())
+    {
+    case Pose::doubleTap:
+        return GESTURE_HOLD_ONE;
+    case Pose::fingersSpread:
+        return GESTURE_HOLD_TWO;
+    case Pose::fist:
+        return GESTURE_HOLD_THREE;
+    case Pose::waveIn:
+        return GESTURE_HOLD_FOUR;
+    case Pose::waveOut:
+        return GESTURE_HOLD_FIVE;
+    default:
+        return GESTURE_HOLD_FIVE;
+    }
+}
+
+static myo::Pose midasHoldModeToMyoPose(midasMode holdMode)
+{
+    switch (holdMode)
+    {
+    case GESTURE_HOLD_ONE:
+        return Pose::doubleTap;
+    case GESTURE_HOLD_TWO:
+        return Pose::fingersSpread;
+    case GESTURE_HOLD_THREE:
+        return Pose::fist;
+    case GESTURE_HOLD_FOUR:
+        return Pose::waveIn;
+    case GESTURE_HOLD_FIVE:
+        return Pose::waveOut;
+    default:
+        return Pose::waveOut;
+    }
+}
 #endif /* _MYO_COMMON_H */

--- a/PMMain/Midas/MidasGUI/MyoState.cpp
+++ b/PMMain/Midas/MidasGUI/MyoState.cpp
@@ -161,6 +161,24 @@ myo::Pose MyoState::popPose()
 	return front;
 }
 
+myo::Pose MyoState::mostRecentPose()
+{
+    myoStateMutex.lock();
+    myo::Pose front;
+    if (poseHistory.size() > 0)
+    {
+        front = poseHistory.back();
+    }
+    else
+    {
+        front = myo::Pose::rest;
+    }
+
+    myoStateMutex.unlock();
+
+    return front;
+}
+
 std::deque<myo::Pose> MyoState::getPoseHistory()
 {
 	myoStateMutex.lock();

--- a/PMMain/Midas/MidasGUI/MyoState.cpp
+++ b/PMMain/Midas/MidasGUI/MyoState.cpp
@@ -192,7 +192,10 @@ void MyoState::setArm(myo::Arm arm)
 
 myo::Arm MyoState::getArm()
 {
-    return this->currentArm;
+    myoStateMutex.lock();
+    myo::Arm retVal = this->currentArm;
+    myoStateMutex.unlock();
+    return retVal;
 }
 
 void MyoState::setWarmupState(myo::WarmupState warmupState)
@@ -204,7 +207,10 @@ void MyoState::setWarmupState(myo::WarmupState warmupState)
 
 myo::WarmupState MyoState::getWarmupState()
 {
-    return this->currentWarmupState;
+    myoStateMutex.lock();
+    myo::WarmupState retVal = this->currentWarmupState;
+    myoStateMutex.unlock();
+    return retVal;
 }
 
 void MyoState::setXDirection(myo::XDirection xDirection)
@@ -216,18 +222,24 @@ void MyoState::setXDirection(myo::XDirection xDirection)
 
 myo::XDirection MyoState::getXDirection()
 {
-    return this->currentXDirection;
+    myoStateMutex.lock();
+    myo::XDirection retVal = this->currentXDirection;
+    myoStateMutex.unlock();
+    return retVal;
 }
 
 bool MyoState::lastPoseNonRest()
 {
+    myoStateMutex.lock();
     if (poseHistory.size() >= 1 &&
         Pose::rest != poseHistory.back())
     {
+        myoStateMutex.unlock();
         return true;
     }
     else
     {
+        myoStateMutex.unlock();
         return false;
     }
 }

--- a/PMMain/Midas/MidasGUI/MyoState.h
+++ b/PMMain/Midas/MidasGUI/MyoState.h
@@ -48,6 +48,7 @@ public:
 	void pushPose(myo::Pose pose);
 	myo::Pose popPose();
 	std::deque<myo::Pose> getPoseHistory();
+    myo::Pose mostRecentPose();
 
     void setMyo(MyoDevice *myo);
     const MyoDevice* peakMyo();

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
@@ -529,20 +529,26 @@ filterError MyoTranslationFilter::updateBasedOnProfile(ProfileManager& pm, std::
             gestType = GESTURE_WAVE_OUT;
         }
 
+        gestHoldModeAction[gestType].setActionType(holdModeActionTypeMap[it->holdModeActionType]);
+        gestHoldModeAction[gestType].setIntervalLen(it->intervalLen);
+
         for (std::vector<angleAction>::iterator angleIt = it->angles.begin(); angleIt != it->angles.end(); ++angleIt)
         {
             angleData ad;
             if (angleIt->type == "roll")
             {
                 ad.angleType = angleData::AngleType::ROLL;
+                gestHoldModeAction[gestType].setRollSensitivity(angleIt->sensitivity);
             }
             else if (angleIt->type == "pitch")
             {
                 ad.angleType = angleData::AngleType::PITCH;
+                gestHoldModeAction[gestType].setPitchSensitivity(angleIt->sensitivity);
             }
             else
             {
                 ad.angleType = angleData::AngleType::YAW;
+                gestHoldModeAction[gestType].setYawSensitivity(angleIt->sensitivity);
             }
 
             ad.anglePositive = true;

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
@@ -30,10 +30,6 @@
 #include "myo\myo.hpp"
 #include <iostream>
 
-/* Test Code - TODO - remove */
-GestureHoldModeAction actions;
-/*  */
-
 SettingsSignaller MyoTranslationFilter::settingsSignaller;
 
 MyoTranslationFilter::MyoTranslationFilter(ControlState* controlState, MyoState* myoState, MainGUI *mainGuiHandle)
@@ -55,20 +51,6 @@ MyoTranslationFilter::MyoTranslationFilter(ControlState* controlState, MyoState*
     }
 
     hmo = NULL;
-    /* Test Code - TODO - remove */
-//   actions.setRollSensitivity(3);
-//   actions.setPitchSensitivity(1);
-//   actions.setYawSensitivity(1);
-//   actions.addToActionMap(angleData(angleData::AngleType::YAW, true), kybdCmds::RIGHT_ARROW);
-//   actions.addToActionMap(angleData(angleData::AngleType::YAW, false), kybdCmds::LEFT_ARROW);
-//   actions.addToActionMap(angleData(angleData::AngleType::PITCH, true), kybdCmds::UP_ARROW);
-//   actions.addToActionMap(angleData(angleData::AngleType::PITCH, false), kybdCmds::DOWN_ARROW);
-//   //actions.addToActionMap(angleData(angleData::AngleType::ROLL, true), kybdCmds::VOLUME_UP);
-//   //actions.addToActionMap(angleData(angleData::AngleType::ROLL, false), kybdCmds::VOLUME_DOWN);
-//
-//   hmo = new HoldModeObserver(myoState, controlState->getSCD(), &actions);// , 1000, HoldModeObserver::ABS_DELTA_FINITE, 2000, 2000);
-//   hmo->kickOffObserver();
-    //*********************************
 }
 
 MyoTranslationFilter::~MyoTranslationFilter()
@@ -496,11 +478,10 @@ bool MyoTranslationFilter::initGestHoldModeActionArr(void)
 
 void MyoTranslationFilter::unregisterHoldModeActions(void)
 {
-    // TODO - re-add this - Jorden July 7 RE ADD THIS!!! And then fix profiles.xml to parse holds properly.
-//    for (int i = 0; i < NUM_GESTURES; i++)
-//    {
-//        gestHoldModeAction[i].clearMap();
-//    }
+    for (int i = 0; i < NUM_GESTURES; i++)
+    {
+        gestHoldModeAction[i].clearMap();
+    }
 }
 
 filterError MyoTranslationFilter::updateBasedOnProfile(ProfileManager& pm, std::string name)

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
@@ -55,15 +55,15 @@ MyoTranslationFilter::MyoTranslationFilter(ControlState* controlState, MyoState*
     }
 
     /* Test Code - TODO - remove */
-    actions.setRollSensitivity(1);
+    actions.setRollSensitivity(3);
     actions.setPitchSensitivity(1);
     actions.setYawSensitivity(1);
-    //actions.addToActionMap(angleData(angleData::AngleType::YAW, true), kybdCmds::RIGHT_ARROW);
-    //actions.addToActionMap(angleData(angleData::AngleType::YAW, false), kybdCmds::LEFT_ARROW);
-    //actions.addToActionMap(angleData(angleData::AngleType::PITCH, true), kybdCmds::UP_ARROW);
-    //actions.addToActionMap(angleData(angleData::AngleType::PITCH, false), kybdCmds::DOWN_ARROW);
-    actions.addToActionMap(angleData(angleData::AngleType::ROLL, true), kybdCmds::VOLUME_UP);
-    actions.addToActionMap(angleData(angleData::AngleType::ROLL, false), kybdCmds::VOLUME_DOWN);
+    actions.addToActionMap(angleData(angleData::AngleType::YAW, true), kybdCmds::RIGHT_ARROW);
+    actions.addToActionMap(angleData(angleData::AngleType::YAW, false), kybdCmds::LEFT_ARROW);
+    actions.addToActionMap(angleData(angleData::AngleType::PITCH, true), kybdCmds::UP_ARROW);
+    actions.addToActionMap(angleData(angleData::AngleType::PITCH, false), kybdCmds::DOWN_ARROW);
+    //actions.addToActionMap(angleData(angleData::AngleType::ROLL, true), kybdCmds::VOLUME_UP);
+    //actions.addToActionMap(angleData(angleData::AngleType::ROLL, false), kybdCmds::VOLUME_DOWN);
 
     hmo = new HoldModeObserver(myoState, controlState->getSCD(), &actions);// , 1000, HoldModeObserver::ABS_DELTA_FINITE, 2000, 2000);
     hmo->kickOffObserver();

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
@@ -26,21 +26,15 @@
 #include "MainGUI.h"
 #include "ProfileManager.h"
 #include "BaseMeasurements.h"
+#include "HoldModeObserver.h"
 #include "myo\myo.hpp"
-#include <math.h>
 #include <iostream>
 
+/* Test Code - TODO - remove */
+GestureHoldModeAction actions;
+/*  */
+
 SettingsSignaller MyoTranslationFilter::settingsSignaller;
-
-float radToDeg(float rad)
-{
-    return rad * (180.0 / M_PI);
-}
-
-float degToRad(float deg)
-{
-    return (deg / 180.0) * M_PI;
-}
 
 MyoTranslationFilter::MyoTranslationFilter(ControlState* controlState, MyoState* myoState, MainGUI *mainGuiHandle)
     : controlStateHandle(controlState), myoStateHandle(myoState), previousMode(LOCK_MODE),
@@ -59,10 +53,26 @@ MyoTranslationFilter::MyoTranslationFilter(ControlState* controlState, MyoState*
     {
         mainGui->connectSignallerToSettingsDisplayer(&settingsSignaller);
     }
+
+    /* Test Code - TODO - remove */
+    actions.setRollSensitivity(1);
+    actions.setPitchSensitivity(1);
+    actions.setYawSensitivity(1);
+    //actions.addToActionMap(angleData(angleData::AngleType::YAW, true), kybdCmds::RIGHT_ARROW);
+    //actions.addToActionMap(angleData(angleData::AngleType::YAW, false), kybdCmds::LEFT_ARROW);
+    //actions.addToActionMap(angleData(angleData::AngleType::PITCH, true), kybdCmds::UP_ARROW);
+    //actions.addToActionMap(angleData(angleData::AngleType::PITCH, false), kybdCmds::DOWN_ARROW);
+    actions.addToActionMap(angleData(angleData::AngleType::ROLL, true), kybdCmds::VOLUME_UP);
+    actions.addToActionMap(angleData(angleData::AngleType::ROLL, false), kybdCmds::VOLUME_DOWN);
+
+    hmo = new HoldModeObserver(myoState, controlState->getSCD(), &actions);// , 1000, HoldModeObserver::ABS_DELTA_FINITE, 2000, 2000);
+    hmo->kickOffObserver();
+    //*********************************
 }
 
 MyoTranslationFilter::~MyoTranslationFilter()
 {
+    delete hmo; hmo = NULL;
 }
 
 void MyoTranslationFilter::process()

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
@@ -160,7 +160,7 @@ void MyoTranslationFilter::handleQuatData(filterDataMap input, filterDataMap out
                 gestIdx = 4;
 
             execute:
-                performHoldModeFunc(gestIdx, output);
+                //performHoldModeFunc(gestIdx, output); // Legacy. Not handled like this anymore.
                 break;
             case KEYBOARD_MODE:
                 performeKybdModeFunc(output);
@@ -327,71 +327,71 @@ float MyoTranslationFilter::calcRingDelta(float current, float base)
 
 void MyoTranslationFilter::performHoldModeFunc(unsigned int holdNum, filterDataMap& outputToSharedCommandData)
 {
-    CommandData command;
-    command.type = commandType::KYBRD_CMD;
-    command.name = "HoldMode Command";
-    command.action.kybd = kybdCmds::NO_CMD;
-
-    GestureHoldModeAction currentHoldModeAction = gestHoldModeAction[holdNum];
-    float thresh = .1;
-    
-    CommandData cd;
-    angleData ad;
-    bool tryAction = false;
-
-    ad.angleType = angleData::AngleType::ROLL;
-    if (deltaRollDeg > thresh)
-    {
-        tryAction = true;
-        ad.anglePositive = true;
-        
-    } 
-    else if (deltaRollDeg < -thresh)
-    {
-        tryAction = true;
-        ad.anglePositive = false;
-    }
-    if (tryAction)
-    {
-        command.action.kybd = kybdCmds((unsigned int)command.action.kybd | (unsigned int)currentHoldModeAction.getAction(ad));
-        outputToSharedCommandData[COMMAND_INPUT] = command;
-    }
-
-    tryAction = false;
-    ad.angleType = angleData::AngleType::PITCH;
-    if (deltaPitchDeg > thresh)
-    {
-        tryAction = true;
-        ad.anglePositive = true;
-    }
-    else if (deltaPitchDeg < -thresh)
-    {
-        tryAction = true;
-        ad.anglePositive = false;
-    }
-    if (tryAction)
-    {
-        command.action.kybd = kybdCmds((unsigned int)command.action.kybd | (unsigned int)currentHoldModeAction.getAction(ad));
-        outputToSharedCommandData[COMMAND_INPUT] = command;
-    }
-
-    tryAction = false;
-    ad.angleType = angleData::AngleType::YAW;
-    if (deltaYawDeg > thresh)
-    {
-        tryAction = true;
-        ad.anglePositive = true;
-    }
-    else if (deltaYawDeg < -thresh)
-    {
-        tryAction = true;
-        ad.anglePositive = false;
-    }
-    if (tryAction)
-    {
-        command.action.kybd = kybdCmds((unsigned int)command.action.kybd | (unsigned int)currentHoldModeAction.getAction(ad));
-        outputToSharedCommandData[COMMAND_INPUT] = command;
-    }
+//    CommandData command;
+//    command.type = commandType::KYBRD_CMD;
+//    command.name = "HoldMode Command";
+//    command.action.kybd = kybdCmds::NO_CMD;
+//
+//    GestureHoldModeAction currentHoldModeAction = gestHoldModeAction[holdNum];
+//    float thresh = .1;
+//    
+//    CommandData cd;
+//    angleData ad;
+//    bool tryAction = false;
+//
+//    ad.angleType = angleData::AngleType::ROLL;
+//    if (deltaRollDeg > thresh)
+//    {
+//        tryAction = true;
+//        ad.anglePositive = true;
+//        
+//    } 
+//    else if (deltaRollDeg < -thresh)
+//    {
+//        tryAction = true;
+//        ad.anglePositive = false;
+//    }
+//    if (tryAction)
+//    {
+//        command.action.kybd = kybdCmds((unsigned int)command.action.kybd | (unsigned int)currentHoldModeAction.getAction(ad));
+//        outputToSharedCommandData[COMMAND_INPUT] = command;
+//    }
+//
+//    tryAction = false;
+//    ad.angleType = angleData::AngleType::PITCH;
+//    if (deltaPitchDeg > thresh)
+//    {
+//        tryAction = true;
+//        ad.anglePositive = true;
+//    }
+//    else if (deltaPitchDeg < -thresh)
+//    {
+//        tryAction = true;
+//        ad.anglePositive = false;
+//    }
+//    if (tryAction)
+//    {
+//        command.action.kybd = kybdCmds((unsigned int)command.action.kybd | (unsigned int)currentHoldModeAction.getAction(ad));
+//        outputToSharedCommandData[COMMAND_INPUT] = command;
+//    }
+//
+//    tryAction = false;
+//    ad.angleType = angleData::AngleType::YAW;
+//    if (deltaYawDeg > thresh)
+//    {
+//        tryAction = true;
+//        ad.anglePositive = true;
+//    }
+//    else if (deltaYawDeg < -thresh)
+//    {
+//        tryAction = true;
+//        ad.anglePositive = false;
+//    }
+//    if (tryAction)
+//    {
+//        command.action.kybd = kybdCmds((unsigned int)command.action.kybd | (unsigned int)currentHoldModeAction.getAction(ad));
+//        outputToSharedCommandData[COMMAND_INPUT] = command;
+//    }
 }
 
 void MyoTranslationFilter::performMouseModeFunc(filterDataMap& outputToSharedCommandData)
@@ -531,6 +531,7 @@ filterError MyoTranslationFilter::updateBasedOnProfile(ProfileManager& pm, std::
 
         gestHoldModeAction[gestType].setActionType(holdModeActionTypeMap[it->holdModeActionType]);
         gestHoldModeAction[gestType].setIntervalLen(it->intervalLen);
+        gestHoldModeAction[gestType].setVelocityIntervalLen(it->intervalLen);
 
         for (std::vector<angleAction>::iterator angleIt = it->angles.begin(); angleIt != it->angles.end(); ++angleIt)
         {

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.cpp
@@ -480,7 +480,7 @@ void MyoTranslationFilter::unregisterHoldModeActions(void)
 {
     for (int i = 0; i < NUM_GESTURES; i++)
     {
-        gestHoldModeAction[i].clearMap();
+        gestHoldModeAction[i].clean();
     }
 }
 
@@ -577,7 +577,7 @@ void MyoTranslationFilter::updateHoldModeObserver(midasMode currMode)
     {
         if (hmo == NULL)
         {
-            hmo = new HoldModeObserver(myoStateHandle, controlStateHandle->getSCD(), &gestHoldModeAction[midasHoldModeToMyoPose(currMode).type()]);// , 1000, HoldModeObserver::ABS_DELTA_FINITE, 2000, 2000);
+            hmo = new HoldModeObserver(myoStateHandle, controlStateHandle->getSCD(), &gestHoldModeAction[gestHoldModeActionIdx(currMode)]);
             hmo->kickOffObserver();
         }
     }

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.h
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.h
@@ -172,6 +172,24 @@ private:
         roll, baseRoll, prevRoll, deltaRollDeg;
 
     HoldModeObserver *hmo;
+    int gestHoldModeActionIdx(midasMode mode)
+    {
+        switch (mode)
+        {
+        case GESTURE_HOLD_ONE:
+            return GESTURE_DOUBLE_TAP;
+        case GESTURE_HOLD_TWO:
+            return GESTURE_FINGERS_SPREAD;
+        case GESTURE_HOLD_THREE:
+            return GESTURE_FIST;
+        case GESTURE_HOLD_FOUR:
+            return GESTURE_WAVE_IN;
+        case GESTURE_HOLD_FIVE:
+            return GESTURE_WAVE_OUT;
+        default:
+            return GESTURE_WAVE_OUT;
+        }
+    }
     GestureHoldModeAction gestHoldModeAction[5];
 
     MainGUI *mainGui; // not owned

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.h
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.h
@@ -162,6 +162,8 @@ private:
     bool initGestHoldModeActionArr(void);
     void unregisterHoldModeActions(void);
 
+    void updateHoldModeObserver(midasMode currMode);
+
     ControlState* controlStateHandle; // not owned
     MyoState* myoStateHandle; // not owned
     midasMode previousMode;

--- a/PMMain/Midas/MidasGUI/MyoTranslationFilter.h
+++ b/PMMain/Midas/MidasGUI/MyoTranslationFilter.h
@@ -26,6 +26,7 @@
 #include "ProfileManager.h"
 #include "SettingsSignaller.h"
 #include "myo\myo.hpp"
+#include <math.h>
 
 #ifdef USE_SIMULATOR
 #include "MyoSimIncludes.hpp"
@@ -37,6 +38,7 @@ using namespace myo;
 class MyoState;
 class ControlState;
 class MainGUI;
+class HoldModeObserver;
 
 #define MAX_PITCH_ANGLE 25.0f /* Maximum delta angle in degrees */
 #define MAX_YAW_ANGLE 30.0f /* Maximum delta angle in degrees */
@@ -82,6 +84,16 @@ public:
     * @return a value from -pi to +pi representing the delta between two input angles
     */
     static float calcRingDelta(float current, float base);
+
+    static float radToDeg(float rad)
+    {
+        return rad * (180.0 / M_PI);
+    }
+
+    static float degToRad(float deg)
+    {
+        return (deg / 180.0) * M_PI;
+    }
 
     filterError updateBasedOnProfile(ProfileManager& pm, std::string name);
 
@@ -157,6 +169,7 @@ private:
         yaw, baseYaw, prevYaw, deltaYawDeg,
         roll, baseRoll, prevRoll, deltaRollDeg;
 
+    HoldModeObserver *hmo;
     GestureHoldModeAction gestHoldModeAction[5];
 
     MainGUI *mainGui; // not owned

--- a/PMMain/Midas/MidasGUI/ProfileManager.cpp
+++ b/PMMain/Midas/MidasGUI/ProfileManager.cpp
@@ -136,6 +136,13 @@ std::map <std::string, Pose::Type> profileGestureNameToType =
     { "waveOut", Pose::Type::waveOut }
 };
 
+std::map <std::string, HoldModeActionType> holdModeActionTypeMap =
+{
+    { "absDeltaFinite", ABS_DELTA_FINITE },
+    { "absDeltaVelocity", ABS_DELTA_VELOCITY },
+    { "intervalDelta", INTERVAL_DELTA }
+};
+
 ProfileManager::ProfileManager() { }
 
 ProfileManager::~ProfileManager() { }
@@ -206,12 +213,19 @@ profile ProfileManager::extractProfileInformation(const boost::property_tree::pt
                     std::string angleType = angleVt.second.get<std::string>("<xmlattr>.type");
                     std::string anglePositive = angleVt.second.get_child("anglePositive").get_value<std::string>();
                     std::string angleNegative = angleVt.second.get_child("angleNegative").get_value<std::string>();
+                    unsigned int angleSensitivity = angleVt.second.get_child("sensitivity").get_value<unsigned int>();
                     currAngle.anglePositive = anglePositive;
                     currAngle.angleNegative = angleNegative;
+                    currAngle.sensitivity = angleSensitivity;
                     currAngle.type = angleType;
                     currHold.angles.push_back(currAngle);
                 }
             }
+
+            std::string holdModeActionType = vt.second.get_child("holdModeActionType").get_value<std::string>();
+            unsigned int intervalLen = vt.second.get_child("intervalLength").get_value<unsigned int>();
+            currHold.holdModeActionType = holdModeActionType;
+            currHold.intervalLen = intervalLen;
 
             pr.holds.push_back(currHold);
         }

--- a/PMMain/Midas/MidasGUI/ProfileManager.h
+++ b/PMMain/Midas/MidasGUI/ProfileManager.h
@@ -47,11 +47,14 @@ struct angleAction {
     std::string type;
     std::string anglePositive;
     std::string angleNegative;
+    unsigned int sensitivity;
 };
 
 struct hold {
     std::string gesture;
     std::vector<angleAction> angles;
+    std::string holdModeActionType;
+    unsigned int intervalLen;
 };
 
 struct profile {
@@ -68,6 +71,7 @@ extern std::map<std::string, midasMode> profileActionToStateChange;
 extern std::map<std::string, profileCmds> profileActionToProfileChange;
 extern std::map <std::string, PoseLength> profileGestureTypeToPoseLength;
 extern std::map <std::string, Pose::Type> profileGestureNameToType;
+extern std::map <std::string, HoldModeActionType> holdModeActionTypeMap;
 
 class ProfileManager {
 

--- a/PMMain/Midas/MidasGUI/SCDDigester.cpp
+++ b/PMMain/Midas/MidasGUI/SCDDigester.cpp
@@ -268,6 +268,8 @@ void SCDDigester::digestKybdCmd(CommandData nextCommand)
 {
 	if (nextCommand.action.kybd == kybdCmds::INPUT_VECTOR)
 	{
+        // handle INPUT_VECTOR seperately as KiVector needs to be populated
+        // with each character from the vector.
 		keyboardController->setKiVector(nextCommand.keyboardVector);
 		keyboardController->sendData();
 	}

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -265,11 +265,6 @@
         </sequences>
         <holds>
 			<hold gesture="fingersSpread">
-                <angle type="pitch">
-                    <anglePositive>upArrow</anglePositive>
-                    <angleNegative>downArrow</angleNegative>
-					<sensitivity>3</sensitivity>
-                </angle>
                 <angle type="yaw">
                     <anglePositive>rightArrow</anglePositive>
                     <angleNegative>leftArrow</angleNegative>

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -3,18 +3,6 @@
 <profiles>
 	<profile name="Rotate Model">
         <sequences>
-			<sequence state="lockMode" name="Scroll Up">
-                <gestures>
-					<gesture type="immediate">waveIn</gesture>
-                </gestures>
-                <commands>
-				<command type="mouse">
-                    <actions>
-                        <action>scrollUp</action>
-                    </actions>
-                </command>
-				</commands>
-            </sequence>
 			<sequence state="lockMode" name="Control Mouse">
                 <gestures>
 					<gesture type="tap">fingersSpread</gesture>

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -9,11 +9,11 @@
 					<gesture type="hold">fingersSpread</gesture>
                 </gestures>
                 <commands>
-				<command type="stateChange">
-                    <actions>
-                        <action>gestureHoldTwo</action>
-                    </actions>
-                </command>
+					<command type="stateChange">
+						<actions>
+							<action>gestureHoldTwo</action>
+						</actions>
+					</command>
 				</commands>
             </sequence>
 			<sequence state="gestureHoldTwo" name="Release">
@@ -21,11 +21,35 @@
 					<gesture type="immediate">rest</gesture>
                 </gestures>
                 <commands>
-				<command type="stateChange">
-                    <actions>
-                        <action>lockMode</action>
-                    </actions>
-                </command>
+					<command type="stateChange">
+						<actions>
+							<action>lockMode</action>
+						</actions>
+					</command>
+				</commands>
+            </sequence>
+			<sequence state="lockMode" name="Volume">
+                <gestures>
+					<gesture type="hold">fist</gesture>
+                </gestures>
+                <commands>
+					<command type="stateChange">
+						<actions>
+							<action>gestureHoldThree</action>
+						</actions>
+					</command>
+				</commands>
+            </sequence>
+			<sequence state="gestureHoldThree" name="Release">
+                <gestures>
+					<gesture type="immediate">rest</gesture>
+                </gestures>
+                <commands>
+					<command type="stateChange">
+						<actions>
+							<action>lockMode</action>
+						</actions>
+					</command>
 				</commands>
             </sequence>
 		
@@ -267,12 +291,26 @@
 		
         <holds>
 			<hold gesture="fingersSpread">
-                <angle type="yaw">
+                <angle type="pitch">
+                    <anglePositive>upArrow</anglePositive>
+                    <angleNegative>downArrow</angleNegative>
+					<sensitivity>5</sensitivity>
+                </angle>
+				<angle type="yaw">
                     <anglePositive>rightArrow</anglePositive>
                     <angleNegative>leftArrow</angleNegative>
-					<sensitivity>2</sensitivity>
+					<sensitivity>5</sensitivity>
                 </angle>
-				<holdModeActionType>intervalDelta</holdModeActionType>
+				<holdModeActionType>absDeltaVelocity</holdModeActionType>
+				<intervalLength>100</intervalLength>
+            </hold>
+			<hold gesture="fist">
+                <angle type="roll">
+                    <anglePositive>volumeUp</anglePositive>
+                    <angleNegative>volumeDown</angleNegative>
+					<sensitivity>1</sensitivity>
+                </angle>
+				<holdModeActionType>absDeltaFinite</holdModeActionType>
 				<intervalLength>100</intervalLength>
             </hold>
         </holds>

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -264,6 +264,16 @@
             </sequence>
         </sequences>
         <holds>
+			<hold gesture="fingersSpread">
+                <angle type="pitch">
+                    <anglePositive>upArrow</anglePositive>
+                    <angleNegative>downArrow</angleNegative>
+                </angle>
+                <angle type="yaw">
+                    <anglePositive>rightArrow</anglePositive>
+                    <angleNegative>leftArrow</angleNegative>
+                </angle>
+            </hold>
         </holds>
     </profile>
 	<profile name="Draw on Model">

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -275,9 +275,9 @@
                     <angleNegative>leftArrow</angleNegative>
 					<sensitivity>3</sensitivity>
                 </angle>
+				<holdModeActionType>absDeltaFinite</holdModeActionType>
+				<intervalLength>100</intervalLength>
             </hold>
-			<holdModeActionType>absDeltaFinite</holdModeActionType>
-			<intervalLength>100</intervalLength>
         </holds>
     </profile>
 	<profile name="Draw on Model">
@@ -289,11 +289,11 @@
 					<gesture type="immediate">doubleTap</gesture>
                 </gestures>
                 <commands>
-				<command type="stateChange">
-                    <actions>
-                        <action>mouseMode2</action>
-                    </actions>
-                </command>
+					<command type="stateChange">
+						<actions>
+							<action>mouseMode2</action>
+						</actions>
+					</command>
 				</commands>
             </sequence>
 			<sequence state="mouseMode2" name="Lock">

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -4,7 +4,7 @@
 <profiles>
 	<profile name="Rotate Model">
         <sequences>
-			<sequence state="lockMode" name="Arrow Keys">
+			<sequence state="keyboardMode" name="Arrow Keys">
                 <gestures>
 					<gesture type="hold">fingersSpread</gesture>
                 </gestures>
@@ -23,12 +23,12 @@
                 <commands>
 					<command type="stateChange">
 						<actions>
-							<action>lockMode</action>
+							<action>keyboardMode</action>
 						</actions>
 					</command>
 				</commands>
             </sequence>
-			<sequence state="lockMode" name="Volume">
+			<sequence state="keyboardMode" name="Volume">
                 <gestures>
 					<gesture type="hold">fist</gesture>
                 </gestures>
@@ -47,7 +47,7 @@
                 <commands>
 					<command type="stateChange">
 						<actions>
-							<action>lockMode</action>
+							<action>keyboardMode</action>
 						</actions>
 					</command>
 				</commands>
@@ -315,8 +315,6 @@
             </hold>
         </holds>
     </profile>
-	
-	
 	<profile name="Draw on Model">
         <sequences>
 			<sequence state="lockMode" name="Control Mouse">

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -268,12 +268,16 @@
                 <angle type="pitch">
                     <anglePositive>upArrow</anglePositive>
                     <angleNegative>downArrow</angleNegative>
+					<sensitivity>3</sensitivity>
                 </angle>
                 <angle type="yaw">
                     <anglePositive>rightArrow</anglePositive>
                     <angleNegative>leftArrow</angleNegative>
+					<sensitivity>3</sensitivity>
                 </angle>
             </hold>
+			<holdModeActionType>absDeltaFinite</holdModeActionType>
+			<intervalLength>100</intervalLength>
         </holds>
     </profile>
 	<profile name="Draw on Model">

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -1,4 +1,5 @@
 <?-- this is a comment! -->
+<?-- holdModeActionType absDeltaFinite holdModeActionType -->
 <?xml version="1.0" encoding="utf-8"?>
 <profiles>
 	<profile name="Rotate Model">
@@ -268,9 +269,9 @@
                 <angle type="yaw">
                     <anglePositive>rightArrow</anglePositive>
                     <angleNegative>leftArrow</angleNegative>
-					<sensitivity>3</sensitivity>
+					<sensitivity>10</sensitivity>
                 </angle>
-				<holdModeActionType>absDeltaFinite</holdModeActionType>
+				<holdModeActionType>absDeltaVelocity</holdModeActionType>
 				<intervalLength>100</intervalLength>
             </hold>
         </holds>

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -264,18 +264,21 @@
 				</commands>
             </sequence>
         </sequences>
+		
         <holds>
 			<hold gesture="fingersSpread">
                 <angle type="yaw">
                     <anglePositive>rightArrow</anglePositive>
                     <angleNegative>leftArrow</angleNegative>
-					<sensitivity>10</sensitivity>
+					<sensitivity>2</sensitivity>
                 </angle>
-				<holdModeActionType>absDeltaVelocity</holdModeActionType>
+				<holdModeActionType>intervalDelta</holdModeActionType>
 				<intervalLength>100</intervalLength>
             </hold>
         </holds>
     </profile>
+	
+	
 	<profile name="Draw on Model">
         <sequences>
 			<sequence state="lockMode" name="Control Mouse">

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -3,6 +3,31 @@
 <profiles>
 	<profile name="Rotate Model">
         <sequences>
+			<sequence state="lockMode" name="Arrow Keys">
+                <gestures>
+					<gesture type="hold">fingersSpread</gesture>
+                </gestures>
+                <commands>
+				<command type="stateChange">
+                    <actions>
+                        <action>gestureHoldTwo</action>
+                    </actions>
+                </command>
+				</commands>
+            </sequence>
+			<sequence state="gestureHoldTwo" name="Release">
+                <gestures>
+					<gesture type="immediate">rest</gesture>
+                </gestures>
+                <commands>
+				<command type="stateChange">
+                    <actions>
+                        <action>lockMode</action>
+                    </actions>
+                </command>
+				</commands>
+            </sequence>
+		
 			<sequence state="lockMode" name="Control Mouse">
                 <gestures>
 					<gesture type="tap">fingersSpread</gesture>

--- a/PMMain/Midas/MidasGUI/profiles.xml
+++ b/PMMain/Midas/MidasGUI/profiles.xml
@@ -3,6 +3,18 @@
 <profiles>
 	<profile name="Rotate Model">
         <sequences>
+			<sequence state="lockMode" name="Scroll Up">
+                <gestures>
+					<gesture type="immediate">waveIn</gesture>
+                </gestures>
+                <commands>
+				<command type="mouse">
+                    <actions>
+                        <action>scrollUp</action>
+                    </actions>
+                </command>
+				</commands>
+            </sequence>
 			<sequence state="lockMode" name="Control Mouse">
                 <gestures>
 					<gesture type="tap">fingersSpread</gesture>

--- a/PMMain/Midas/MidasProfileManager/HoldEditor.cpp
+++ b/PMMain/Midas/MidasProfileManager/HoldEditor.cpp
@@ -46,12 +46,16 @@ void HoldEditor::handleDone()
 {
     returnHold.gesture = ui.gestureComboBox->currentText().toStdString();
     
+    returnHold.holdModeActionType = ui.holdModeActionType->currentText().toStdString();
+    returnHold.intervalLen = ui.intervalLength->value();
+
     if (isAngleSet(ui.rollPositiveComboBox, ui.rollNegativeComboBox))
     {
         AngleAction roll;
         roll.type = "roll";
         roll.anglePositive = ui.rollPositiveComboBox->currentText().toStdString();
         roll.angleNegative = ui.rollNegativeComboBox->currentText().toStdString();
+        roll.sensitivity = ui.rollSensitivity->value();
 
         returnHold.angles.push_back(roll);
     }
@@ -62,6 +66,7 @@ void HoldEditor::handleDone()
         pitch.type = "pitch";
         pitch.anglePositive = ui.pitchPositiveComboBox->currentText().toStdString();
         pitch.angleNegative = ui.pitchNegativeComboBox->currentText().toStdString();
+        pitch.sensitivity = ui.pitchSensitivity->value();
 
         returnHold.angles.push_back(pitch);
     }
@@ -72,6 +77,7 @@ void HoldEditor::handleDone()
         yaw.type = "yaw";
         yaw.anglePositive = ui.yawPositiveComboBox->currentText().toStdString();
         yaw.angleNegative = ui.yawNegativeComboBox->currentText().toStdString();
+        yaw.sensitivity = ui.yawSensitivity->value();
 
         returnHold.angles.push_back(yaw);
     }

--- a/PMMain/Midas/MidasProfileManager/HoldEditor.ui
+++ b/PMMain/Midas/MidasProfileManager/HoldEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
-    <height>375</height>
+    <width>459</width>
+    <height>442</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -70,7 +70,7 @@
      <x>10</x>
      <y>40</y>
      <width>261</width>
-     <height>91</height>
+     <height>111</height>
     </rect>
    </property>
    <property name="title">
@@ -422,14 +422,43 @@
      </property>
     </item>
    </widget>
+   <widget class="QLabel" name="label_9">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>80</y>
+      <width>81</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Sensitivity:</string>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="rollSensitivity">
+    <property name="geometry">
+     <rect>
+      <x>110</x>
+      <y>80</y>
+      <width>42</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>30</number>
+    </property>
+   </widget>
   </widget>
   <widget class="QGroupBox" name="groupBox_2">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>140</y>
+     <y>160</y>
      <width>261</width>
-     <height>91</height>
+     <height>111</height>
     </rect>
    </property>
    <property name="title">
@@ -781,14 +810,43 @@
      </property>
     </item>
    </widget>
+   <widget class="QSpinBox" name="pitchSensitivity">
+    <property name="geometry">
+     <rect>
+      <x>110</x>
+      <y>80</y>
+      <width>42</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>30</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_10">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>80</y>
+      <width>81</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Sensitivity:</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QGroupBox" name="groupBox_3">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>240</y>
+     <y>280</y>
      <width>261</width>
-     <height>91</height>
+     <height>111</height>
     </rect>
    </property>
    <property name="title">
@@ -1140,18 +1198,117 @@
      </property>
     </item>
    </widget>
+   <widget class="QSpinBox" name="yawSensitivity">
+    <property name="geometry">
+     <rect>
+      <x>110</x>
+      <y>80</y>
+      <width>42</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>30</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_11">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>80</y>
+      <width>81</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Sensitivity:</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QPushButton" name="doneButton">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>340</y>
+     <y>400</y>
      <width>75</width>
      <height>23</height>
     </rect>
    </property>
    <property name="text">
     <string>Done</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_12">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>50</y>
+     <width>131</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Hold Mode Action Type:</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="holdModeActionType">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>70</y>
+     <width>111</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <item>
+    <property name="text">
+     <string>absDeltaFinite</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>absDeltaVelocity</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>intervalDelta</string>
+    </property>
+   </item>
+  </widget>
+  <widget class="QLabel" name="label_13">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>100</y>
+     <width>131</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Interval Length (ms):</string>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="intervalLength">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>120</y>
+     <width>111</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="minimum">
+    <number>20</number>
+   </property>
+   <property name="maximum">
+    <number>999999</number>
+   </property>
+   <property name="value">
+    <number>100</number>
    </property>
   </widget>
  </widget>

--- a/PMMain/Midas/MidasProfileManager/HoldEditor.ui
+++ b/PMMain/Midas/MidasProfileManager/HoldEditor.ui
@@ -36,13 +36,8 @@
     </rect>
    </property>
    <property name="currentText">
-    <string>doubleTap</string>
+    <string>fist</string>
    </property>
-   <item>
-    <property name="text">
-     <string>doubleTap</string>
-    </property>
-   </item>
    <item>
     <property name="text">
      <string>fist</string>

--- a/PMMain/Midas/MidasProfileManager/ProfileWidget.cpp
+++ b/PMMain/Midas/MidasProfileManager/ProfileWidget.cpp
@@ -101,6 +101,10 @@ void ProfileWidget::drawHold(Hold hold, int ind, bool insertBefore)
     grouper->setMaximumSize(400, 310);
 
     QVBoxLayout* holdLayout = new QVBoxLayout();
+
+    std::string description = "holdModeActionType: " + hold.holdModeActionType + "; intervalLen: " + std::to_string(hold.intervalLen);
+    QLabel* descLabel = new QLabel(QString(description.c_str()));
+    holdLayout->addWidget(descLabel);
     
     for (int i = 0; i < hold.angles.size(); i++)
     {
@@ -109,8 +113,8 @@ void ProfileWidget::drawHold(Hold hold, int ind, bool insertBefore)
         QLabel* angleLabel = new QLabel(QString(angleTitle.c_str()));
         holdLayout->addWidget(angleLabel);
 
-        std::string positiveText = "    On positive angle, do action '" + angle.anglePositive + "'";
-        std::string negativeText = "    On negative angle, do action '" + angle.angleNegative + "'";
+        std::string positiveText = "    On positive angle, do action '" + angle.anglePositive + "' with Sensitivity: " + std::to_string(angle.sensitivity);
+        std::string negativeText = "    On negative angle, do action '" + angle.angleNegative + "' with Sensitivity: " + std::to_string(angle.sensitivity);
         QLabel* positiveLabel = new QLabel(QString(positiveText.c_str()));
         QLabel* negativeLabel = new QLabel(QString(negativeText.c_str()));
 

--- a/PMMain/Midas/MidasProfileManager/ProfileWriter.cpp
+++ b/PMMain/Midas/MidasProfileManager/ProfileWriter.cpp
@@ -1,20 +1,20 @@
 /*
-Copyright (C) 2015 Midas
+    Copyright (C) 2015 Midas
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-USA
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+    USA
 */
 
 #include "ProfileWriter.h"
@@ -83,6 +83,8 @@ void ProfileWriter::writeProfile(boost::property_tree::ptree &profileNode, Profi
         {
             ptree &holdNode = profileNode.add("holds.hold", "");
             holdNode.put("<xmlattr>.gesture", hold.gesture);
+            holdNode.add("holdModeActionType", hold.holdModeActionType);
+            holdNode.add("intervalLength", hold.intervalLen);
 
             BOOST_FOREACH(AngleAction angleAction, hold.angles)
             {
@@ -91,6 +93,7 @@ void ProfileWriter::writeProfile(boost::property_tree::ptree &profileNode, Profi
 
                 angleNode.add("anglePositive", angleAction.anglePositive);
                 angleNode.add("angleNegative", angleAction.angleNegative);
+                angleNode.add("sensitivity", angleAction.sensitivity);
             }
         }
     }
@@ -172,7 +175,11 @@ Profile ProfileWriter::extractProfileInformation(const boost::property_tree::ptr
         {
             Hold currHold;
             std::string gesture = vt.second.get<std::string>("<xmlattr>.gesture");
+            std::string holdModeActionType = vt.second.get_child("holdModeActionType").get_value<std::string>();
+            unsigned int intervalLen = vt.second.get_child("intervalLength").get_value<unsigned int>();
             currHold.gesture = gesture;
+            currHold.holdModeActionType = holdModeActionType;
+            currHold.intervalLen = intervalLen;
 
             BOOST_FOREACH(const ptree::value_type & angleVt, vt.second)
             {
@@ -182,8 +189,10 @@ Profile ProfileWriter::extractProfileInformation(const boost::property_tree::ptr
                     std::string angleType = angleVt.second.get<std::string>("<xmlattr>.type");
                     std::string anglePositive = angleVt.second.get_child("anglePositive").get_value<std::string>();
                     std::string angleNegative = angleVt.second.get_child("angleNegative").get_value<std::string>();
+                    unsigned int angleSensitivity = angleVt.second.get_child("sensitivity").get_value<unsigned int>();
                     currAngle.anglePositive = anglePositive;
                     currAngle.angleNegative = angleNegative;
+                    currAngle.sensitivity = angleSensitivity;
                     currAngle.type = angleType;
                     currHold.angles.push_back(currAngle);
                 }

--- a/PMMain/Midas/MidasProfileManager/ProfileWriter.cpp
+++ b/PMMain/Midas/MidasProfileManager/ProfileWriter.cpp
@@ -175,11 +175,7 @@ Profile ProfileWriter::extractProfileInformation(const boost::property_tree::ptr
         {
             Hold currHold;
             std::string gesture = vt.second.get<std::string>("<xmlattr>.gesture");
-            std::string holdModeActionType = vt.second.get_child("holdModeActionType").get_value<std::string>();
-            unsigned int intervalLen = vt.second.get_child("intervalLength").get_value<unsigned int>();
             currHold.gesture = gesture;
-            currHold.holdModeActionType = holdModeActionType;
-            currHold.intervalLen = intervalLen;
 
             BOOST_FOREACH(const ptree::value_type & angleVt, vt.second)
             {
@@ -197,6 +193,11 @@ Profile ProfileWriter::extractProfileInformation(const boost::property_tree::ptr
                     currHold.angles.push_back(currAngle);
                 }
             }
+
+            std::string holdModeActionType = vt.second.get_child("holdModeActionType").get_value<std::string>();
+            unsigned int intervalLen = vt.second.get_child("intervalLength").get_value<unsigned int>();
+            currHold.holdModeActionType = holdModeActionType;
+            currHold.intervalLen = intervalLen;
 
             pr.holds.push_back(currHold);
         }

--- a/PMMain/Midas/MidasProfileManager/ProfileWriter.h
+++ b/PMMain/Midas/MidasProfileManager/ProfileWriter.h
@@ -45,11 +45,14 @@ struct AngleAction {
     std::string type;
     std::string anglePositive;
     std::string angleNegative;
+    unsigned int sensitivity;
 };
 
 struct Hold {
     std::string gesture;
     std::vector<AngleAction> angles;
+    std::string holdModeActionType;
+    unsigned int intervalLen;
 };
 
 struct Profile {


### PR DESCRIPTION
Implemented hold mode architecture properly as to deal with time appropriately as opposed to simply spewing key press events while in the hold mode (as it was before). Now there are three unique types of holdModeActionTypes:
1)    ABS_DELTA_FINITE, // Based on the net delta beyond threshold, ensure the number of +/- actions is at a certain value (repeatable change)
2)    ABS_DELTA_VELOCITY, // Based on net delta beyond threshold, continue spewing actions
3)    INTERVAL_DELTA // if in a given interval an angle is +/- beyond a threshold, >=1 action will ensue 

Also, the profileManager has been updated to appropriately read/write xml files that incorporate this data.
